### PR TITLE
Add Stripe demo merchant storefront for EnsureBack testing

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+STRIPE_SECRET_KEY=sk_test_your_secret_key
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
+DOMAIN=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.env.local
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# testmerchant
-An online merchant for testing
+# Test Merchant Store
+
+Sample single-product merchant storefront used to test the EnsureBack integration against Stripe Checkout.
+
+## Features
+
+- One-click checkout for a single demo product (Test Headphones - $99.00)
+- Stripe Checkout + PaymentIntent flow with metadata for EnsureBack
+- In-memory tracking of order lifecycle events
+- Webhook endpoint that records successful payments
+- Internal APIs for EnsureBack to query orders, release funds, and request refunds
+
+## Getting Started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Configure environment variables by copying `.env` and adding your Stripe test keys:
+
+   ```bash
+   cp .env .env.local
+   # Edit .env.local with your STRIPE_SECRET_KEY and STRIPE_WEBHOOK_SECRET
+   ```
+
+   The application reads `.env` by default. For local development you can use `.env` or `.env.local` (just ensure the values are exported before starting the app).
+
+3. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+   Or start without hot reloading:
+
+   ```bash
+   npm start
+   ```
+
+4. Visit [http://localhost:3000](http://localhost:3000) and complete a payment using Stripe's test card `4242 4242 4242 4242`.
+
+## API Endpoints
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `POST` | `/create-checkout-session` | Creates a Stripe Checkout Session for the demo product. |
+| `POST` | `/webhook` | Stripe webhook listener (expects `checkout.session.completed`). |
+| `GET` | `/orders` | Lists all known orders with their status. |
+| `POST` | `/orders/:id/release` | Simulates releasing escrowed funds for the order. |
+| `POST` | `/orders/:id/refund` | Initiates a Stripe refund for the captured PaymentIntent. |
+
+All endpoints currently log requests and responses to the console to aid with EnsureBack integration testing.
+
+## Webhook Testing
+
+1. Start the server and expose it via a tunneling tool such as [Stripe CLI](https://stripe.com/docs/stripe-cli) or [ngrok](https://ngrok.com/).
+2. Configure the Stripe webhook endpoint to point at `https://<your-tunnel>/webhook` and listen for `checkout.session.completed` events.
+3. Confirm that webhook deliveries update the in-memory order store and log a message such as `Order <orderId> marked as paid`.
+
+## Refund Testing
+
+1. Trigger a successful payment to create an order in the `paid` state.
+2. Call `POST /orders/:id/refund` to initiate a refund through Stripe.
+3. Observe the order status transition to `refunded` and review the console logs for the order lifecycle.
+
+## Notes
+
+- The project keeps order data in memory only; restarting the server will clear all order history.
+- These APIs intentionally omit authentication to simplify EnsureBack testing. Add appropriate auth before using in production.
+- Replace the placeholder Stripe keys in `.env` with your own test keys before running checkout flows.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "testmerchant",
+  "version": "1.0.0",
+  "description": "Sample single-product merchant site for EnsureBack integration testing",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "keywords": [
+    "stripe",
+    "checkout",
+    "ensureback",
+    "merchant"
+  ],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "stripe": "^14.24.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.4"
+  }
+}

--- a/public/cancel.html
+++ b/public/cancel.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Payment Canceled - Test Merchant Store</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-slate-100 min-h-screen">
+    <main class="max-w-2xl mx-auto px-6 py-16">
+      <div class="bg-white rounded-2xl shadow-lg p-10 text-center space-y-6">
+        <div class="mx-auto h-16 w-16 rounded-full bg-rose-100 flex items-center justify-center">
+          <span class="text-rose-600 text-4xl">×</span>
+        </div>
+        <h1 class="text-3xl font-bold text-slate-900">Payment canceled</h1>
+        <p class="text-slate-600">
+          Your checkout session was canceled before completion. You can return to the store and try again at any time.
+        </p>
+        <a
+          href="/"
+          class="inline-block mt-6 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-lg hover:bg-indigo-500"
+        >
+          Back to store
+        </a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Test Merchant Store</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-slate-100 min-h-screen">
+    <header class="bg-white shadow-sm">
+      <div class="max-w-4xl mx-auto px-6 py-4 flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-slate-900">Test Merchant Store</h1>
+        <p class="text-sm text-slate-500">EnsureBack Checkout Demo</p>
+      </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 py-12">
+      <section class="bg-white rounded-2xl shadow-lg p-8 flex flex-col gap-6 md:flex-row md:items-center">
+        <div class="flex-1">
+          <h2 class="text-3xl font-bold text-slate-900">Test Headphones</h2>
+          <p class="mt-4 text-slate-600">
+            Experience immersive, crystal-clear sound with our premium over-ear headphones.
+            This demo product powers the EnsureBack escrow testing flow.
+          </p>
+          <ul class="mt-6 space-y-2 text-slate-600">
+            <li>• Studio-grade sound quality</li>
+            <li>• Active noise cancellation</li>
+            <li>• Comfortable memory-foam cushions</li>
+          </ul>
+          <p class="mt-8 text-3xl font-semibold text-indigo-600">$99.00</p>
+        </div>
+        <div class="w-full md:w-80">
+          <form id="checkout-form" class="space-y-4 bg-slate-50 p-6 rounded-xl border border-slate-200">
+            <label class="block text-sm font-medium text-slate-700" for="email">Email address</label>
+            <input
+              id="email"
+              type="email"
+              name="email"
+              class="w-full rounded-lg border border-slate-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              placeholder="you@example.com"
+              required
+            />
+            <button
+              id="buy-now"
+              type="submit"
+              class="w-full bg-indigo-600 text-white font-semibold py-3 rounded-lg hover:bg-indigo-500 transition disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Buy Now
+            </button>
+            <p id="message" class="text-sm text-center text-red-500 hidden"></p>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="max-w-4xl mx-auto px-6 pb-8 text-sm text-slate-500">
+      <p>
+        Use Stripe test card <span class="font-semibold">4242 4242 4242 4242</span> with any future expiration date and CVC
+        for demo payments.
+      </p>
+    </footer>
+
+    <script>
+      const form = document.getElementById('checkout-form');
+      const message = document.getElementById('message');
+      const buyButton = document.getElementById('buy-now');
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        message.classList.add('hidden');
+        buyButton.disabled = true;
+        buyButton.textContent = 'Creating checkout...';
+
+        const email = document.getElementById('email').value;
+
+        try {
+          const response = await fetch('/create-checkout-session', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ email }),
+          });
+
+          if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.error || 'Unable to start checkout.');
+          }
+
+          const data = await response.json();
+          window.location.href = data.url;
+        } catch (err) {
+          message.textContent = err.message;
+          message.classList.remove('hidden');
+          buyButton.disabled = false;
+          buyButton.textContent = 'Buy Now';
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/public/success.html
+++ b/public/success.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Payment Successful - Test Merchant Store</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-slate-100 min-h-screen">
+    <main class="max-w-2xl mx-auto px-6 py-16">
+      <div class="bg-white rounded-2xl shadow-lg p-10 text-center space-y-6">
+        <div class="mx-auto h-16 w-16 rounded-full bg-emerald-100 flex items-center justify-center">
+          <span class="text-emerald-600 text-4xl">✓</span>
+        </div>
+        <h1 class="text-3xl font-bold text-slate-900">Payment successful!</h1>
+        <p class="text-slate-600">
+          Thank you for your purchase. Your order has been received and is ready for EnsureBack testing.
+        </p>
+        <dl class="grid grid-cols-1 gap-4 text-left">
+          <div class="bg-slate-50 border border-slate-200 rounded-xl p-4">
+            <dt class="text-xs uppercase tracking-wide text-slate-500">Order ID</dt>
+            <dd id="order-id" class="mt-1 font-mono text-sm text-slate-900">Loading...</dd>
+          </div>
+          <div class="bg-slate-50 border border-slate-200 rounded-xl p-4">
+            <dt class="text-xs uppercase tracking-wide text-slate-500">Stripe Session ID</dt>
+            <dd id="session-id" class="mt-1 font-mono text-sm text-slate-900">Loading...</dd>
+          </div>
+          <div class="bg-slate-50 border border-slate-200 rounded-xl p-4">
+            <dt class="text-xs uppercase tracking-wide text-slate-500">Current Status</dt>
+            <dd id="order-status" class="mt-1 font-semibold text-emerald-600">Waiting for webhook...</dd>
+          </div>
+        </dl>
+        <a
+          href="/"
+          class="inline-block mt-6 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-lg hover:bg-indigo-500"
+        >
+          Back to store
+        </a>
+      </div>
+    </main>
+
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      const orderId = params.get('orderId');
+      const sessionId = params.get('session_id');
+
+      const orderIdEl = document.getElementById('order-id');
+      const sessionIdEl = document.getElementById('session-id');
+      const statusEl = document.getElementById('order-status');
+
+      if (orderId) {
+        orderIdEl.textContent = orderId;
+      } else {
+        orderIdEl.textContent = 'Unknown order';
+      }
+
+      if (sessionId) {
+        sessionIdEl.textContent = sessionId;
+      } else {
+        sessionIdEl.textContent = 'Unavailable';
+      }
+
+      async function refreshStatus() {
+        try {
+          const response = await fetch('/orders');
+          const orders = await response.json();
+          const order = orders.find((entry) => entry.orderId === orderId);
+
+          if (order) {
+            statusEl.textContent = order.status;
+            statusEl.classList.toggle('text-emerald-600', order.status === 'paid' || order.status === 'released');
+            statusEl.classList.toggle('text-orange-500', order.status === 'pending');
+            statusEl.classList.toggle('text-rose-600', order.status === 'refunded');
+          }
+        } catch (err) {
+          statusEl.textContent = 'Unable to load status';
+          statusEl.classList.remove('text-emerald-600');
+          statusEl.classList.add('text-rose-600');
+        }
+      }
+
+      if (orderId) {
+        refreshStatus();
+        setInterval(refreshStatus, 4000);
+      }
+    </script>
+  </body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,200 @@
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+const crypto = require('crypto');
+const Stripe = require('stripe');
+const dotenv = require('dotenv');
+
+// Load environment variables from .env / .env.local if available
+dotenv.config();
+const localEnvPath = path.join(__dirname, '.env.local');
+if (fs.existsSync(localEnvPath)) {
+  dotenv.config({ path: localEnvPath, override: true });
+}
+
+const app = express();
+const port = process.env.PORT || 3000;
+const domain = process.env.DOMAIN || `http://localhost:${port}`;
+
+if (!process.env.STRIPE_SECRET_KEY) {
+  console.warn('[Startup] STRIPE_SECRET_KEY is not set. Stripe API calls will fail until it is configured.');
+}
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2024-06-20',
+});
+
+// In-memory order store
+const orders = new Map();
+
+// Middleware setup
+app.use(express.static(path.join(__dirname, 'public')));
+app.use('/webhook', express.raw({ type: 'application/json' }));
+app.use(express.json());
+
+const PRODUCT = {
+  name: 'Test Headphones',
+  description: 'High-fidelity over-ear headphones for integration testing.',
+  amount: 9900,
+  currency: 'usd',
+};
+
+app.post('/create-checkout-session', async (req, res) => {
+  const { email } = req.body || {};
+
+  try {
+    if (!process.env.STRIPE_SECRET_KEY) {
+      return res.status(500).json({ error: 'Stripe secret key not configured.' });
+    }
+
+    const orderId = crypto.randomUUID();
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      payment_method_types: ['card'],
+      metadata: {
+        orderId,
+        productName: PRODUCT.name,
+        buyerEmail: email || '',
+      },
+      line_items: [
+        {
+          price_data: {
+            currency: PRODUCT.currency,
+            product_data: {
+              name: PRODUCT.name,
+              description: PRODUCT.description,
+            },
+            unit_amount: PRODUCT.amount,
+          },
+          quantity: 1,
+        },
+      ],
+      customer_email: email || undefined,
+      success_url: `${domain}/success.html?orderId=${orderId}&session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${domain}/cancel.html`,
+    });
+
+    const orderRecord = {
+      orderId,
+      sessionId: session.id,
+      status: 'pending',
+      amount: PRODUCT.amount,
+      currency: PRODUCT.currency,
+      email: email || null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      paymentIntentId: null,
+      releaseTimestamp: null,
+      refundId: null,
+    };
+
+    orders.set(orderId, orderRecord);
+
+    console.log(`[Checkout] Created session ${session.id} for order ${orderId}`);
+
+    return res.json({ url: session.url, orderId });
+  } catch (error) {
+    console.error('[Checkout] Failed to create session:', error);
+    return res.status(500).json({ error: 'Unable to create checkout session.' });
+  }
+});
+
+app.get('/orders', (req, res) => {
+  const result = Array.from(orders.values());
+  console.log('[Orders] Listing orders:', result.map((order) => ({ orderId: order.orderId, status: order.status })));
+  res.json(result);
+});
+
+app.post('/orders/:id/release', (req, res) => {
+  const { id } = req.params;
+  const order = orders.get(id);
+
+  if (!order) {
+    return res.status(404).json({ error: 'Order not found.' });
+  }
+
+  order.status = 'released';
+  order.releaseTimestamp = new Date().toISOString();
+  order.updatedAt = new Date().toISOString();
+  orders.set(id, order);
+
+  console.log(`[Orders] Release funds called for order ${id}`);
+
+  res.json({ message: `Funds released for order ${id}.`, order });
+});
+
+app.post('/orders/:id/refund', async (req, res) => {
+  const { id } = req.params;
+  const order = orders.get(id);
+
+  if (!order) {
+    return res.status(404).json({ error: 'Order not found.' });
+  }
+
+  if (!order.paymentIntentId) {
+    return res.status(400).json({ error: 'Order has no captured payment to refund yet.' });
+  }
+
+  try {
+    const refund = await stripe.refunds.create({
+      payment_intent: order.paymentIntentId,
+    });
+
+    order.status = 'refunded';
+    order.refundId = refund.id;
+    order.updatedAt = new Date().toISOString();
+    orders.set(id, order);
+
+    console.log(`[Orders] Refund created for order ${id}: refund ${refund.id}`);
+
+    res.json({ message: `Refund initiated for order ${id}.`, refund, order });
+  } catch (error) {
+    console.error(`[Orders] Failed to refund order ${id}:`, error);
+    res.status(500).json({ error: 'Unable to process refund for this order.' });
+  }
+});
+
+app.post('/webhook', (req, res) => {
+  const signature = req.headers['stripe-signature'];
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  let event;
+
+  try {
+    if (webhookSecret) {
+      event = stripe.webhooks.constructEvent(req.body, signature, webhookSecret);
+    } else {
+      const payload = Buffer.isBuffer(req.body) ? req.body.toString('utf8') : req.body;
+      event = JSON.parse(payload);
+    }
+  } catch (err) {
+    console.error('[Webhook] Signature verification failed:', err.message);
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  console.log(`[Webhook] Received event: ${event.type}`);
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object;
+    const orderId = session.metadata?.orderId;
+
+    if (orderId && orders.has(orderId)) {
+      const order = orders.get(orderId);
+      order.status = 'paid';
+      order.paymentIntentId = session.payment_intent;
+      order.sessionId = session.id;
+      order.updatedAt = new Date().toISOString();
+      orders.set(orderId, order);
+
+      console.log(`[Webhook] Order ${orderId} marked as paid (payment_intent=${session.payment_intent}).`);
+    } else {
+      console.warn(`[Webhook] Unknown order ID from session ${session.id}.`);
+    }
+  }
+
+  res.json({ received: true });
+});
+
+app.listen(port, () => {
+  console.log(`Merchant demo server running at ${domain}`);
+});


### PR DESCRIPTION
## Summary
- add an Express server that creates Stripe Checkout sessions, handles webhooks, and tracks in-memory order state
- expose EnsureBack helper APIs for listing, releasing, and refunding orders
- build Tailwind-powered static pages and documentation for the single-product storefront

## Testing
- not run (dependencies unavailable in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e030589d3c832a99a83744b6d0c4ea